### PR TITLE
Updating the units of memory parameter

### DIFF
--- a/managing-cf/quota-plans.html.md.erb
+++ b/managing-cf/quota-plans.html.md.erb
@@ -21,7 +21,7 @@ Quota plans are not directly associated with user accounts. Instead, every organ
   <td>name</td><td>The name you use to identify the plan</td><td>A sequence of letters, digits, and underscore characters. Quota plan names within an account must be unique.</td><td>sliver_quota</td>
 </tr>
 <tr>
-  <td>memory_limit</td><td>Maximum memory usage (in MB) allowed</td><td>integer</td><td>2048</td>
+  <td>memory_limit</td><td>Maximum memory usage allowed</td><td>integer with a unit of measurement like M, MB, G, or GB</td><td>2048M</td>
 </tr>
 <tr>
   <td>non_basic_services_allowed</td><td>Determines whether users can provision instances of non-free service plans. Does not control plan visibility. When false, non-free service plans may be visible in the marketplace but instances can not be provisioned.</td><td>true/false</td><td>true</td>
@@ -69,13 +69,13 @@ You can create a new quota plan in one of two ways:
     ```
     quota_definitions:
       default:
-        memory_limit: 10240
+        memory_limit: 10240M
         non_basic_services_allowed: true
         total_routes: 1000
         total_services: 100
         trial_db_allowed: true
       silver_quota:
-        memory_limit: 2048
+        memory_limit: 2048M
         non_basic_services_allowed: true
         total_routes: 500
         total_services: 25
@@ -95,7 +95,7 @@ $ cf create-quota  QUOTA [-m MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [--allow
 Example:
 
  ```
-$ cf create-quota small -m 2048 -r 10 -s 10 --allow-paid-service-plans
+$ cf create-quota small -m 2048M -r 10 -s 10 --allow-paid-service-plans
  ```
 
 # <a id='modify'></a> Modifying a Quota Plan #
@@ -137,6 +137,6 @@ cf update-quota QUOTA [-m MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCE
 Example:
 
  ```
-$ cf update-quota small -m 4096 -n medium -r 20 -s 20 --allow-paid-service-plans
+$ cf update-quota small -m 4096M -n medium -r 20 -s 20 --allow-paid-service-plans
  ```
 <p class="note"><strong>Note</strong>: To create or modify quotas for individual spaces rather than across an entire organization, you can use the <code>space-quota</code> command. It is almost identical to the <code>quota</code> command. For example: to create a quota for a space, use <code>create-space-quota</code>. To modify that quota, use the <code>update-quota</code> command. The org manager sets and manages the space quotas.


### PR DESCRIPTION
memory(-m) parameter in quota can receive different units like M, MB, G, or GB whereas in current doc's there is no units specified in the examples.
```
root@ubuntu:~# cf create-quota asif -m 1024
Creating quota asif as admin...
FAILED
Invalid memory limit: 1024
Byte quantity must be an integer with a unit of measurement like M, MB, G, or GB
```