### PR TITLE
Cc ng console

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -346,8 +346,27 @@ Note the job name and index of the failing VM.
 1. Run `sudo su -` to enter the root environment with root privileges.
 1. Run `monit summary` to determine which processes are not running.
 1. Review the log files found in `/var/vcap/sys/log/` to determine the root
-cause of the process failures.
+cause of the process failures. Some of these logs are formatted using steno, with timestamps instead of human formatted dates. Use `steno-prettify` to format it for humans
 1. Use `monit restart all` or `monit restart PROCESS` to start the processes.
+
+Execute the following commands to set up steno-prettify in the cloudcontroller:
+
+<pre class="terminal">
+export CC_JOB_DIR=/var/vcap/jobs/cloud_controller_ng
+source $CC_JOB_DIR/bin/ruby_version.sh
+
+CC_PACKAGE_DIR=/var/vcap/packages/cloud_controller_ng
+export BUNDLE_GEMFILE=$CC_PACKAGE_DIR/cloud_controller_ng/Gemfile
+export HOME=/home/vcap # rake needs it to be set to run tasks
+
+if [ -f $BUNDLE_GEMFILE ]; then
+	alias  steno-prettify="bundle exec steno-prettify"
+	echo "ready to use steno-prettify alias, try steno-prettify on one of the following files:"
+	find /var/vcap/sys/log/ -name "*.log" | egrep  -v "err|out|ctl" | xargs ls -al
+else
+	echo "could not find Gemfile into ${STENO_DIR}:" `ls -al ${BUNDLE_GEMFILE}`
+fi
+</pre>
 
 ###<a id="force-recreate"></a>Forcing a VM Recreate ###
 

--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -368,6 +368,17 @@ else
 fi
 </pre>
 
+###<a id="debugging-cloudcontroller"></a>Interactive cloudcontroller shell ###
+
+The cloud controller jobs embeds a pry shell, see http://pryrepl.org/ for some background. This may allow to interact with
+cc_ng classes such as scripting some operations or access the cc_db using model classes, see [example](https://www.pivotaltracker.com/story/show/81076206)
+
+<pre class="terminal">
+$ cd /var/vcap/jobs/cloud_controller_ng
+$ bin/console
+[...]
+</pre>
+
 ###<a id="force-recreate"></a>Forcing a VM Recreate ###
 
 If BOSH or an operator identifies a VM as corrupted, BOSH can recreate the VM.


### PR DESCRIPTION
Adds mention of cc_ng console, added ontop of https://github.com/cloudfoundry/docs-running-cf/pull/7 which might be ignored then.