### PR TITLE
Update fingerprint generation procedure

### DIFF
--- a/config-ssh.html.md.erb
+++ b/config-ssh.html.md.erb
@@ -25,6 +25,11 @@ Enabling SSH access requires generating a RSA key pair for your SSH proxy.
 <pre class="terminal">$ ssh-keygen -f ssh-proxy-host-key.pem
 $ ssh-keygen -lf ssh-proxy-host-key.pem.pub | cut -d ' ' -f2 > ssh-proxy-host-key-fingerprint
 </pre>
+<p class="note"><strong>Note</strong>: Recent versions of ssh-keygen print SHA256 fingerprint hashes of the keys. To get MD5 hashes of the server key fingerprints (the old behaviour), the -E option can be used to specify the hash algorithm</p>
+<pre class="terminal">$ ssh-keygen -f ssh-proxy-host-key.pem
+$ ssh-keygen -E md5 -lf ssh-proxy-host-key.pem.pub | sed 's/MD5://' | cut -d ' ' -f2 > ssh-proxy-host-key-fingerprint
+</pre>
+
 1. Locate your PEM-encoded private key in `ssh-proxy-host-key.pem` and your public key fingerprint in `ssh-proxy-host-key-fingerprint`. You will need to copy the contents of these files into your Cloud Foundry and Diego manifests.
 
 ### <a id='cf-manifest'></a> Configure Your Cloud Foundry Manifest


### PR DESCRIPTION
Starting openssh 6.8, fingerprints default format is SHA256. 
The manifest only accepts MD5 fingerprints. 