### PR TITLE
Add new metric `cc.diego_sync.duration` to docs.

### DIFF
--- a/metrics/_cloud_controller.html.md.erb
+++ b/metrics/_cloud_controller.html.md.erb
@@ -2,7 +2,7 @@ Default Origin Name: cc
 
 Metric Name                                         | Description
 ----------------------------------------------------|--------------------------------------------------------------------------------------------------
-diego\_sync.duration                                | Time in nanoseconds that it took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.
+diego\_sync.duration                                | Time in milliseconds that it took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.
 failed\_job\_count.\<VM\_NAME\>-\<VM\_INDEX\>         | Number of failed jobs in the \<VM\_NAME\>-\<VM\_INDEX\> queue. This is the number of delayed jobs where the `failed at` column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 failed\_job\_count.cc-generic                       | Number of failed jobs in the cc-generic queue. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 failed\_job\_count.total                            | Number of failed jobs in all queues. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.

--- a/metrics/_cloud_controller.html.md.erb
+++ b/metrics/_cloud_controller.html.md.erb
@@ -2,6 +2,7 @@ Default Origin Name: cc
 
 Metric Name                                         | Description
 ----------------------------------------------------|--------------------------------------------------------------------------------------------------
+diego\_sync.duration                                | Time in nanoseconds that it took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.
 failed\_job\_count.\<VM\_NAME\>-\<VM\_INDEX\>         | Number of failed jobs in the \<VM\_NAME\>-\<VM\_INDEX\> queue. This is the number of delayed jobs where the `failed at` column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 failed\_job\_count.cc-generic                       | Number of failed jobs in the cc-generic queue. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 failed\_job\_count.total                            | Number of failed jobs in all queues. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.


### PR DESCRIPTION
Please don't merge until @zrob gives the thumbs-up.

---

Add new metric `cc.diego_sync.duration` to docs.

[**\[#145950089\]**](https://www.pivotaltracker.com/n/projects/966314/stories/145950089)

Signed-off-by: Annie Sing <asing@pivotal.io>