### PR TITLE
Add documentation for routes_pruned metric

### DIFF
--- a/metrics/_routing.html.md.erb
+++ b/metrics/_routing.html.md.erb
@@ -43,6 +43,7 @@ Routing Release metrics have following origin names:
  total\_routes                      | Current number of routes registered. Emitted every 30 seconds.
  uptime                             | Uptime for router. Emitted every second.
  file_descriptors                   | Number of file descriptors currently used by gorouter. Emitted every 5 seconds.
+ routes_pruned                      | Lifetime number of stale routes that have been automatically pruned by gorouter.  Emitted every 5 seconds.
 
 <a id="routing_api"></a>Default Origin Name: routing_api
 


### PR DESCRIPTION
👋 

Tracker story: [operator should discover a metric that increments with each route pruned](https://www.pivotaltracker.com/story/show/150560165)