### PR TITLE
Update the cell cleanup logic

### DIFF
--- a/config-cell-cleanup.html.md.erb
+++ b/config-cell-cleanup.html.md.erb
@@ -34,96 +34,39 @@ from the cell disk.
 The disk cleanup process will remove all unused Docker image layers
 and old CF Stacks,
 regardless of their size or age.
+The sum of disk space used by all unused layer is what we call Cache.
 
 ## <a id='options'></a> Options for Disk Cleanup
 
 CF provides the following options
 for scheduling the disk cleanup process
-on Diego cells: 
+on Diego cells:
 
-* **Never clean up the Cell Disk**:
-  We do not recommend using this option
-  for production environments.
-* **Routinely clean up the Cell Disk**:
+* **Always clean up the Cell Disk**:
   This option makes the cell schedule a disk cleanup
   every time a container gets created.
   Running the disk cleanup process so frequently
   may have a negative impact on the cell performance.
-* **Clean up Disk space once a threshold is reached**:
+* **Clean up Disk space once cache size is reached**:
   Choosing this option makes the cell schedule the disk cleanup process
-  only when a configurable disk space threshold is reached or exceeded.
+  only when a configurable cache size is reached or exceeded.
 
 See the [Configure Disk Cleanup Scheduling](#applying-configuration) section for how to choose one these options.
 
-### <a id='recommendations'></a> Recommendations
+### <a id='choosing-a-cache-size'></a> Choosing a Cache Size
 
-Choosing the best option for disk cleanup depends
-on the workload that the Diego cells run:
-Docker images or Cloud Foundry buildpack-based apps.
+The default value is 10GB, which should be sufficient for almost all use cases.
+This value should never be bigger than 50% of the ephemeral disk, or there is the risk of the cell running out of disk space.
 
-For CF installations that mainly run **buildpack-based applications**
-we recommend using the second option:
-**Routinely clean up Cell Disk space**. 
-The **Routinely clean up Cell Disk space** option ensures
-that when a new stack becomes available on a cell,
-the old stack is dropped immediately from the cache.
+Setting this value too low will result in a better management of disk space, but sacrifice performance.
+The cell will need to clean up more often and also redownload images more frequently.
 
-For CF installations that mainly run **Docker images**,
-or both Docker images and buildpack-based apps,
-we recommend using the third option:
-**Clean up Disk space once a threshold is reached**
-along with a reasonable threshold.
-Choosing a threshold is described in
-[Choosing a Threshold](#choosing-a-threshold).
-
-### <a id='choosing-a-threshold'></a> Choosing a Threshold
-
-To choose a realistic value when configuring the disk cleanup threshold,
-you must identify some of the most frequently used Docker images
-in your CF installation.
-Docker images tend to be constructed
-by creating layers over existing, base, images.
-In some cases, you may find it easier
-to identify which base Docker images are most frequently used.  
-
-Follow the steps below to configure the disk cleanup threshold:
-
-1. Identify the most frequently used Docker images or base Docker images. 
-<br><br>Example: The most frequently used images in a test deployment are `openjdk:7`, `nginx:1.13`, and `php:7-apache`.
-
-1. Using the Docker CLI, measure the size of those images.
-<br><br>
-Example:
-    <pre class="terminal">
-    \# Pull identified images locally
-    $> docker pull openjdk:7
-    $> docker pull nginx:1.13
-    $> docker pull php:7-apache
-
-    \# Measure their sizes
-    $> docker images
-    REPOSITORY       TAG          IMAGE ID          CREATED             SIZE
-    php              7-apache     2720c02fc079      2 days ago          391 MB
-    openjdk          7            f45207c01009      5 days ago          586 MB
-    nginx            1.13         3448f27c273f      5 days ago          109 MB
-    ...
-    </pre>
-
-1. Calculate the threshold as the sum of the frequently used image sizes plus a reasonable buffer such as 15-20%.
-<br><br>
-Example: Using the output above, the sample threshold calculation is (&nbsp;391&nbsp;MB&nbsp;+&nbsp;586&nbsp;MB&nbsp;+&nbsp;109&nbsp;MB&nbsp;)&nbsp;*&nbsp;1.2&nbsp;=&nbsp;1303.2&nbsp;MB
+Setting this value too high will enhance performance, but could lead to insufficient disk space
+for applications to run, resulting in schedulling errors.
 
 ## <a id='applying-configuration'></a> Configure Disk Cleanup Scheduling
 
-To control how Diego cells schedule their disk cleanup, set the BOSH property `garden.graph_cleanup_threshold_in_mb` to one of the following [options](#options):
+To control how Diego cells schedule their disk cleanup, set the BOSH property `grootfs.cache_size_bytes` to one of the following [options](#options):
 
-* `-1`: the cell never runs disk cleanup.
 * `0`: the cell runs disk cleanup whenever it creates a new container.
-* A positive number: the cell runs disk cleanup whenever its total disk usage exceeds the number, in MB. The number acts as the threshold.
-  <br><br>
-  Example: As calculated in the previous step,
-  you would set the BOSH property to **1303**.
-
-If you are deploying CF with [GrootFS](https://github.com/cloudfoundry/grootfs-release)
-then please configure
-the `grootfs.graph_cleanup_threshold_in_mb` option instead.
+* A positive number: the cell runs disk cleanup whenever its total unused layer size exceeds the number, in bytes. The number acts as the cache size.


### PR DESCRIPTION
With the new grootfs `cache_size_bytes` the disk clean up is triggered
based on the size of unused layers instead of the total amount of disk
used.

Also there's no more an option to "never clean".

-> https://www.pivotaltracker.com/story/show/145801375

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>