### PR TITLE
Revert "Update the cell cleanup logic"

### DIFF
--- a/config-cell-cleanup.html.md.erb
+++ b/config-cell-cleanup.html.md.erb
@@ -10,47 +10,119 @@ in Cloud Foundry (CF).
 
 ## <a id='what'></a> What is Disk Cleanup
 
-CF isolates application instances (AIs) from each other using containers that 
-run inside Diego cells.
-Containers enforce a set of isolation layers including file system isolation.
-A CF container file system can either be a CF stack or the result of pulling 
-a Docker image.
+CF isolates application instances (AIs) from each other
+using containers that run inside Diego cells.
+Containers enforce a set of isolation layers
+including file system isolation.
+A CF container file system can either be
+a CF stack
+or the result of pulling a Docker image.
 
-For performance reasons, the cells cache the Docker image layers and the CF stacks used by running application instances.
-When CF destroys an AI or reschedules an AI to a different cell, there exists the possibility that certain Docker image layers or an old CF stack become unused.
-If CF does not delete these unused layers, the cell ephemeral disk can fill.
+For performance reasons,
+the cells cache the Docker image layers and the CF stacks
+that running AIs use.
+When CF destroys an AI (e.g.: as a result of `cf delete`)
+or when CF reschedules an AI to a different cell,
+there is a chance that certain Docker image layers,
+or an old CF stack
+will become unused.
+If CF does not clean these unused layers
+the cell ephemeral disk will slowly fill.
 
-Disk cleanup is the process of removing unused layers from the cell disk.
-The disk cleanup process removes all unused Docker image layers and old CF stacks, regardless of their size or age.
-The sum of disk space used by all unused layer called the **cell cache**, or just **cache**.
+Disk cleanup is the process of removing unused layers
+from the cell disk.
+The disk cleanup process will remove all unused Docker image layers
+and old CF Stacks,
+regardless of their size or age.
 
 ## <a id='options'></a> Options for Disk Cleanup
 
-CF provides the following options for scheduling the disk cleanup process on 
-Diego cells:
+CF provides the following options
+for scheduling the disk cleanup process
+on Diego cells: 
 
-* **Always clean up the Cell Disk**:
-  This option makes the cell schedule a disk cleanup every time a container is  
-  created. Running the disk cleanup process this frequently
-  can result in a negative impact on the cell performance.
-* **Clean up Disk space once cache size is reached**:
-  This option makes the cell schedule the disk cleanup only when a configurable 
-  cache size is reached or exceeded.
+* **Never clean up the Cell Disk**:
+  We do not recommend using this option
+  for production environments.
+* **Routinely clean up the Cell Disk**:
+  This option makes the cell schedule a disk cleanup
+  every time a container gets created.
+  Running the disk cleanup process so frequently
+  may have a negative impact on the cell performance.
+* **Clean up Disk space once a threshold is reached**:
+  Choosing this option makes the cell schedule the disk cleanup process
+  only when a configurable disk space threshold is reached or exceeded.
 
 See the [Configure Disk Cleanup Scheduling](#applying-configuration) section of this topic to select one of these options.
 
-### <a id='choosing-a-cache-size'></a> Choosing a Cache Size
+### <a id='recommendations'></a> Recommendations
 
-The default cache size is 10&nbsp;GB, which is typically sufficient for almost all use cases.
-You should never set cache size to greater than 50% of the ephemeral disk, or the cell may run out of disk space.
+Choosing the best option for disk cleanup depends
+on the workload that the Diego cells run:
+Docker images or Cloud Foundry buildpack-based apps.
 
-Setting the cache size to a low value results in improved disk space management at the cost of performance. The cell must run the cleanup process more frequently, and re-download images more frequently.
+For CF installations that mainly run **buildpack-based applications**
+we recommend using the second option:
+**Routinely clean up Cell Disk space**. 
+The **Routinely clean up Cell Disk space** option ensures
+that when a new stack becomes available on a cell,
+the old stack is dropped immediately from the cache.
 
-Setting the cache size to a high value results in enhanced performance but can result in providing insufficient disk space for applications. This can result in scheduling errors.
+For CF installations that mainly run **Docker images**,
+or both Docker images and buildpack-based apps,
+we recommend using the third option:
+**Clean up Disk space once a threshold is reached**
+along with a reasonable threshold.
+Choosing a threshold is described in
+[Choosing a Threshold](#choosing-a-threshold).
+
+### <a id='choosing-a-threshold'></a> Choosing a Threshold
+
+To choose a realistic value when configuring the disk cleanup threshold,
+you must identify some of the most frequently used Docker images
+in your CF installation.
+Docker images tend to be constructed
+by creating layers over existing, base, images.
+In some cases, you may find it easier
+to identify which base Docker images are most frequently used.  
+
+Follow the steps below to configure the disk cleanup threshold:
+
+1. Identify the most frequently used Docker images or base Docker images. 
+<br><br>Example: The most frequently used images in a test deployment are `openjdk:7`, `nginx:1.13`, and `php:7-apache`.
+
+1. Using the Docker CLI, measure the size of those images.
+<br><br>
+Example:
+    <pre class="terminal">
+    \# Pull identified images locally
+    $> docker pull openjdk:7
+    $> docker pull nginx:1.13
+    $> docker pull php:7-apache
+
+    \# Measure their sizes
+    $> docker images
+    REPOSITORY       TAG          IMAGE ID          CREATED             SIZE
+    php              7-apache     2720c02fc079      2 days ago          391 MB
+    openjdk          7            f45207c01009      5 days ago          586 MB
+    nginx            1.13         3448f27c273f      5 days ago          109 MB
+    ...
+    </pre>
+
+1. Calculate the threshold as the sum of the frequently used image sizes plus a reasonable buffer such as 15-20%.
+<br><br>
+Example: Using the output above, the sample threshold calculation is (&nbsp;391&nbsp;MB&nbsp;+&nbsp;586&nbsp;MB&nbsp;+&nbsp;109&nbsp;MB&nbsp;)&nbsp;*&nbsp;1.2&nbsp;=&nbsp;1303.2&nbsp;MB
 
 ## <a id='applying-configuration'></a> Configure Disk Cleanup Scheduling
 
-To control how Diego cells schedule their disk cleanup, set the BOSH property `grootfs.cache_size_bytes` to one of the following [options](#options):
+To control how Diego cells schedule their disk cleanup, set the BOSH property `garden.graph_cleanup_threshold_in_mb` to one of the following [options](#options):
 
 * **0**: The cell runs disk cleanup whenever it creates a new container.
-* **A positive integer**: The cell runs disk cleanup whenever the total unused layer size, in bytes, exceeds this number. 
+* **A positive integer**: the cell runs disk cleanup whenever its total disk usage exceeds the number, in MB. The number acts as the threshold.
+  <br><br>
+  Example: As calculated in the previous step,
+  you would set the BOSH property to **1303**.
+
+If you are deploying CF with [GrootFS](https://github.com/cloudfoundry/grootfs-release)
+then please configure
+the `grootfs.graph_cleanup_threshold_in_mb` option instead.


### PR DESCRIPTION
The `cache-size` changes in grootfs were reverted, CF now uses the same
old logic for cleaning the store.

[#152679255]

This reverts commit 08e38f7e5836e8f198cc243d774a61d3ee5a1e5f.