### PR TITLE
Document `cc.deployments.update.duration` metric

### DIFF
--- a/metrics/_cloud_controller.html.md.erb
+++ b/metrics/_cloud_controller.html.md.erb
@@ -3,7 +3,7 @@ Default Origin Name: cc
 Metric Name                                         | Description
 ----------------------------------------------------|--------------------------------------------------------------------------------------------------
 deployments.deploying                               | Number of deployments in the `DEPLOYING` state. Emitted every 30 seconds.
-deployments.update.duration                         | Time in milliseconds that it took to complete an update of app deployments. Emitted every update cycle.
+deployments.update.duration                         | Time in milliseconds that it took to complete an update of app deployments. Emitted every 5 seconds.
 diego_sync.invalid_desired_lrps                     | Number of invalid DesiredLRPs found during CF apps and Diego DesiredLRPs periodic synchronization. Emitted every 30 seconds.
 failed\_job\_count.\<VM\_NAME\>-\<VM\_INDEX\>       | Number of failed jobs in the \<VM\_NAME\>-\<VM\_INDEX\> queue. This is the number of delayed jobs where the `failed at` column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 diego\_sync.duration                                | Time in milliseconds that it took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.

--- a/metrics/_cloud_controller.html.md.erb
+++ b/metrics/_cloud_controller.html.md.erb
@@ -3,6 +3,7 @@ Default Origin Name: cc
 Metric Name                                         | Description
 ----------------------------------------------------|--------------------------------------------------------------------------------------------------
 deployments.deploying                               | Number of deployments in the `DEPLOYING` state. Emitted every 30 seconds.
+deployments.update.duration                         | Time in milliseconds that it took to complete an update of app deployments. Emitted every update cycle.
 diego_sync.invalid_desired_lrps                     | Number of invalid DesiredLRPs found during CF apps and Diego DesiredLRPs periodic synchronization. Emitted every 30 seconds.
 failed\_job\_count.\<VM\_NAME\>-\<VM\_INDEX\>       | Number of failed jobs in the \<VM\_NAME\>-\<VM\_INDEX\> queue. This is the number of delayed jobs where the `failed at` column is populated with the time of the most recently failed attempt at the job. The failed job count is not specific to the jobs run by the Cloud Controller worker. By default, Cloud Controller deletes failed jobs after 31 days. Emitted every 30 seconds per VM.
 diego\_sync.duration                                | Time in milliseconds that it took to synchronize CF apps and Diego DesiredLRPs. Emitted every 30 seconds.


### PR DESCRIPTION
Hello Docs Team!

**NOTE: Please don't merge until @zrob has accepted our story and approved this!**

We're adding a new metric to Cloud Controller that will be emitted by our new `cc_deployment_updater` component that will handle zero-downtime (ZDT) app deployments. Every ~5 seconds ([this is a configurable value](https://bosh.io/jobs/cc_deployment_updater?source=github.com/cloudfoundry/capi-release&version=1.65.0#p%3ddeployment_updater.update_frequency_in_seconds)) it will go through every `DEPLOYING` Deployment and further them along. This metric denotes the duration of each cycle.

**CAPI Story:** [#157984433](https://www.pivotaltracker.com/story/show/157984433)

Thanks!