### PR TITLE
Update Volume Services Page

### DIFF
--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -70,13 +70,7 @@ To deploy the NFS test server, you can fetch the operations file from the [persi
 	<span style="font-family:monospace">  nfstestserver: {export_cidr: 192.168.0.0/16}</span>
 </p>
 
-###<a id="broker"></a>Register the NFS Broker
-
-1. Register the broker using the credentials specified in the `creds.yml` stub.
-  <pre class="terminal">
-$ cf create-service-broker nfsbroker nfs-broker BROKER-PASSWORD \
-		http://nfs-broker.YOUR-SYSTEM-DOMAIN
-  </pre>
+###<a id="broker"></a>Grant access to the NFS Broker
 
 1. Grant access to the services of the broker.
   <pre class="terminal">

--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -53,9 +53,7 @@ This procedure requires the following:
 
 <p class="note"><strong>Note</strong>: The above command is an example, but your deployment command should match the one you used to deploy CF initially, with the addition of a <code>-o operations/enable-nfs-volume-service.yml</code> option.</p>
 
-Your CF deployment now has a running service broker and volume drivers and is ready to mount nfs volumes. BOSH generates a variable for your nfsbroker password, unless you have explicitly defined one.  You can find the broker registration password with the `bosh interpolate` command:
-  <pre class="terminal">
-  $ bosh int deployment-vars.yml --path /nfs-broker-password</pre>
+Your CF deployment now has a running service broker and volume drivers and is ready to mount nfs volumes.
 
 ####<a id="server"></a>Deploying the NFS Test Server
 

--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -51,7 +51,11 @@ This procedure requires the following:
   $ bosh -e my-env -d cf deploy cf.yml -v deployment-vars.yml \
 		-o operations/enable-nfs-volume-service.yml</pre>
 
-<p class="note"><strong>Note</strong>: The above command is an example, but your deployment command should match the one you used to deploy CF initially, with the addition of a <code>-o operations/enable-nfs-volume-service.yml</code> option.</p>
+1. Run the `nfsbrokerpush` errand to deploy the NFS service broker application:
+  <pre class="terminal">
+  $ bosh -e my-env -d cf run-errand nfsbrokerpush</pre>
+
+<p class="note"><strong>Note</strong>: The above <code>bosh deploy</code> command is an example, but your deployment command should match the one you used to deploy CF initially, with the addition of a <code>-o operations/enable-nfs-volume-service.yml</code> option.</p>
 
 Your CF deployment now has a running service broker and volume drivers and is ready to mount nfs volumes.
 


### PR DESCRIPTION
Hi,

This PR updates the volume services page to correct issues with the instructions:

- we have deleted the comment about running bosh interpolate to retrieve the broker password as it is no longer required and it does not work when you are using credhub to store your deployment variables
- we have added an instruction to run the nfsbrokerpush errand after deploying cf
- we have deleted the instruction to manually register the NFS service broker as that is handled by the nfsbrokerpush errand

Please let us know if you have any questions.

Thanks,
Dave and @mariash 