### PR TITLE
Update deploy-vol-services.html.md.erb to remove reference to 'nfs-experimental'

### DIFF
--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -75,7 +75,6 @@ Grant access to the services of the broker.
   
 <pre class="terminal">
 $ cf enable-service-access nfs
-$ cf enable-service-access nfs-experimental
 </pre>
 
 CF Developers can now create an NFS service and bind instances to their apps as outlined in the [Using an External File System (Volume Services)](../devguide/services/using-vol-services.html) topic.


### PR DESCRIPTION
This docs update reflects upcoming changes in nfs-volume-release. We are promoting the existing nfs-experimental service from "experimental" to "production" and deprecating the original fuse-based nfs service to "nfs-legacy".

This PR is dependent on the next release of nfs-volume-release to 1.5.4.

#160406301

Signed-off-by: Paul Warren paul.warren@emc.com

@julian-hj @mariash @WebDave