### PR TITLE
Add SMB section to the Adding Volume Services guide

### DIFF
--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -26,19 +26,19 @@ For more information about volume services and the drivers and brokers available
 
 If you have any questions, you can contact the team that develops volume services for CF on the **#persi** channel in the [Cloud Foundry (Open Source)](https://cloudfoundry.slack.com) Slack organization.
 
-##<a id="example"></a> Example: Deploy NFS Volume Service to CF
+##<a id="nfs-example"></a> Example 1: Deploy NFS Volume Service to CF
 
 The following procedure provides an example of how to deploy the NFS broker and corresponding driver to an existing CF deployment.
 
-###<a id="pre"></a>Prerequisites
+###<a id="nfs-pre"></a>Prerequisites
 
 This procedure requires the following:
 
 * A current version of Cloud Foundry deployed [as described here](/deploying/index.html).
 * A BOSH v2 CLI.
-* An NFS Server. If you require it, a test server can be deployed following the instructions [below](#server).
+* An NFS Server. If you require it, a test server can be deployed following the instructions [below](#nfs-server).
 
-###<a id="redeploy"></a>Redeploy CF with NFS Enabled
+###<a id="nfs-redeploy"></a>Redeploy CF with NFS Enabled
 
 1. Clone the cf-deployment repository from git, if you do not already have it:
   <pre class="terminal">
@@ -58,21 +58,21 @@ This procedure requires the following:
 
 Your CF deployment now has a running service broker and volume drivers and is ready to mount NFS volumes.
 
-####<a id="server"></a>Deploying the NFS Test Server
+####<a id="nfs-server"></a>Deploying the NFS Test Server
 
 To deploy the NFS test server, you can fetch the operations file from the [persi-ci github repository](https://github.com/cloudfoundry/nfs-volume-release/blob/master/operations/enable-nfs-test-server.yml) and include that operation with a `-o` flag. This creates a separate VM with nfs exports you can use to experiment with volume mounts.
 
-<p class="note"><strong>Note</strong>: By default, the nfs test server expects that your CF deployment is deployed to a 10.x.x.x subnet.  If you are deploying to a subnet that is not 10.x.x.x (e.g. 192.168.x.x) then you will need to override the "export_cidr" property.<br/>
+<p class="note"><strong>Note</strong>: By default, the nfs test server expects that your CF deployment is deployed to a 10.x.x.x subnet.  If you are deploying to a subnet that is not 10.x.x.x (e.g. 192.168.x.x) then you will need to override the `export_cidr` property.<br/>
  Edit the operations file, and replace this line:<br/>
  <span style="font-family:monospace">  nfstestserver: {}</span><br/>
  with something like this:<br/>
 	<span style="font-family:monospace">  nfstestserver: {export_cidr: 192.168.0.0/16}</span>
 </p>
 
-###<a id="broker"></a>Grant Access to the NFS Broker
+###<a id="nfs-broker"></a>Grant Access to the NFS Broker
 
 Grant access to the services of the broker.
-  
+
 <pre class="terminal">
 $ cf enable-service-access nfs
 $ cf enable-service-access nfs-experimental
@@ -80,6 +80,57 @@ $ cf enable-service-access nfs-experimental
 
 CF Developers can now create an NFS service and bind instances to their apps as outlined in the [Using an External File System (Volume Services)](../devguide/services/using-vol-services.html) topic.
 
-###<a id="ldap"></a>(Optional) LDAP Support
+###<a id="nfs-ldap"></a>(Optional) LDAP Support
 
   For better security, it is recommended to configure your deployment of nfs-volume-release to connect to an external LDAP server to resolve user credentials into uids.  See [this note](https://github.com/cloudfoundry/nfs-volume-release/USING_LDAP.md) for more details.
+
+##<a id="smb-example"></a> Example 2: Deploy SMB Volume Service to CF
+
+The following procedure provides an example of how to deploy the SMB broker and corresponding driver to an existing CF deployment.
+
+###<a id="smb-pre"></a>Prerequisites
+
+This procedure requires the following:
+
+* A current version of Cloud Foundry deployed [as described here](/deploying/index.html).
+* A BOSH v2 CLI.
+* An SMB Server. If you require it, a test server can be deployed following the instructions [below](#smb-server).
+
+###<a id="smb-redeploy"></a>Redeploy CF with SMB Enabled
+
+1. Clone the cf-deployment repository from git, if you do not already have it:
+  <pre class="terminal">
+  $ cd ~/workspace
+  $ git clone https<span>:</span>//github.com/cloudfoundry/cf-deployment.git
+  $ cd ~/workspace/cf-deployment</pre>
+
+1. Redeploy your cf-deployment while including the smb ops file:
+  <pre class="terminal">
+  $ bosh -e my-env -d cf deploy cf.yml -v deployment-vars.yml \
+		-o operations/experimental/enable-smb-volume-service.yml</pre>
+    <p class="note"><strong>Note</strong>: The above <code>bosh deploy</code> command is an example, but your deployment command should match the one you used to deploy CF initially, with the addition of a <code>-o operations/experimental/enable-smb-volume-service.yml</code> option.</p>
+
+1. Run the `smbbrokerpush` errand to deploy the SMB service broker application:
+  <pre class="terminal">
+  $ bosh -e my-env -d cf run-errand smbbrokerpush</pre>
+
+Your CF deployment now has a running service broker and volume drivers and is ready to mount existing SMB shares.
+
+####<a id="smb-server"></a>Deploying the SMB Test Server
+
+To deploy the SMB test server, you can fetch the operations file from the [persi-ci github repository](https://github.com/cloudfoundry/smb-volume-release/blob/master/operations/enable-smb-test-server.yml) and include that operation with a `-o` flag. This creates a separate VM with smb shares you can use to experiment with volume mounts.
+
+<p class="note"><strong>Note</strong>: By default, the smb test server expects that your CF deployment is deployed to a 10.x.x.x subnet.  If you are deploying to a subnet that is not 10.x.x.x (e.g. 192.168.x.x) then you will need to override the `export_cidr` property.<br/>
+ Edit the operations file, and add a line in the properties section:<br/>
+	<span style="font-family:monospace">export_cidr: 192.168.0.0/16</span>
+</p>
+
+###<a id="smb-broker"></a>Grant Access to the SMB Broker
+
+Grant access to the services of the broker.
+
+<pre class="terminal">
+$ cf enable-service-access smb
+</pre>
+
+CF Developers can now create an SMB service and bind instances to their apps as outlined in the [Using an External File System (Volume Services)](../devguide/services/using-vol-services.html) topic.

--- a/deploy-vol-services.html.md.erb
+++ b/deploy-vol-services.html.md.erb
@@ -60,7 +60,7 @@ Your CF deployment now has a running service broker and volume drivers and is re
 
 ####<a id="server"></a>Deploying the NFS Test Server
 
-To deploy the NFS test server, you can fetch the operations file from the [persi-ci github repository](https://github.com/cloudfoundry/persi-ci/blob/master/operations/enable-nfs-test-server.yml) and include that operation with a `-o` flag. This creates a separate VM with nfs exports you can use to experiment with volume mounts.
+To deploy the NFS test server, you can fetch the operations file from the [persi-ci github repository](https://github.com/cloudfoundry/nfs-volume-release/blob/master/operations/enable-nfs-test-server.yml) and include that operation with a `-o` flag. This creates a separate VM with nfs exports you can use to experiment with volume mounts.
 
 <p class="note"><strong>Note</strong>: By default, the nfs test server expects that your CF deployment is deployed to a 10.x.x.x subnet.  If you are deploying to a subnet that is not 10.x.x.x (e.g. 192.168.x.x) then you will need to override the "export_cidr" property.<br/>
  Edit the operations file, and replace this line:<br/>


### PR DESCRIPTION
We added a second example on how to enable SMB shares support in CF to the `Adding Volume Services` guide. We also fixed a URL to enable-nfs-testserver ops file.

Maria & @davewalter 