### PR TITLE
Fix ambiguous description of X-RateLimit-Reset

### DIFF
--- a/rate-limit-cloud-controller-api.html.md.erb
+++ b/rate-limit-cloud-controller-api.html.md.erb
@@ -26,7 +26,7 @@ Use this table to understand the rate limit header.
  </tr>
  <tr>
  	<td>X-RateLimit-Reset</td>
- 	<td>The time remaining before the rate limit counter resets, in UTC <a href="https://en.wikipedia.org/wiki/Unix_time">epoch seconds</a>.</td>
+ 	<td>The time when the rate limit counter resets, in UTC <a href="https://en.wikipedia.org/wiki/Unix_time">epoch seconds</a>.</td>
  </tr>
 </table>
 


### PR DESCRIPTION
The meaning of `X-RateLimit-Reset` is not the time remaining in epoch seconds, but rather the time in epoch seconds at which the counter resets.