### PR TITLE
Add audit.app.droplet.download

### DIFF
--- a/managing-cf/audit-events.html.md.erb
+++ b/managing-cf/audit-events.html.md.erb
@@ -166,6 +166,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.app.droplet.create
 - audit.app.droplet.delete
 - audit.app.droplet.download
+- audit.app.droplet.upload
 - audit.app.droplet.mapped
 - audit.app.map-route
 - audit.app.package.create


### PR DESCRIPTION
The VAT team added a new audit event for when users upload a droplet using the V3 API. This PR adds it to the list of audit events here: https://docs.cloudfoundry.org/running/managing-cf/audit-events.html

[#165795606](https://www.pivotaltracker.com/story/show/165795606)

Co-authored-by: Eli Wrenn <ewrenn@pivotal.io>