### PR TITLE
Correct language in uaa-audit-requirements.

### DIFF
--- a/managing-cf/uaa-audit-requirements.html.md.erb
+++ b/managing-cf/uaa-audit-requirements.html.md.erb
@@ -32,12 +32,12 @@ UAA includes the following authentication and password events:
 * `UserAuthenticationFailure`
     - **Trigger:** When a user authentication fails, user exists
     - **Data Recorded:** Username
-    - **Notes:** Followed by a `PrincipalAuthenticationFailureEvent`
+    - **Notes:** Followed by a `PrincipalAuthenticationFailure`
 
 * `UserNotFound`
     - **Trigger:** When a user authentication fails, user does not exists
     - **Data Recorded:** Username
-    - **Notes:** Followed by a `PrincipalAuthenticationFailureEvent`
+    - **Notes:** Followed by a `PrincipalAuthenticationFailure`
 
 * `UnverifiedUserAuthentication`
     - **Trigger:** When a user that is not yet verified authenticates
@@ -78,7 +78,7 @@ UAA includes the following authentication and password events:
 * `IdentityProviderAuthenticationFailure`
     - **Trigger:** When a user authentication fails for the password login, and user exists
     - **Data Recorded:** User ID
-    - **Notes:** Followed by a `UserAuthenticationFailureEvent` and `PrincipalAuthenticationFailureEvent`
+    - **Notes:** Followed by a `UserAuthenticationFailureEvent` and `PrincipalAuthenticationFailure`
 
 * `MfaAuthenticationSuccess`
     - **Trigger:** When a user successfully authenticates with MFA


### PR DESCRIPTION
- Change references of `PrincipalAuthenticationFailureEvent` to
`PrincipalAuthenticationFailure`

[#164156515]

Signed-off-by: Stephane Jolicoeur <sjolicoeur@pivotal.io>
Co-authored-by: Stephane Jolicoeur <sjolicoeur@pivotal.io>