### PR TITLE
Adding Audit Event

### DIFF
--- a/managing-cf/audit-events.html.md.erb
+++ b/managing-cf/audit-events.html.md.erb
@@ -160,6 +160,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 
 - audit.app.copy-bits
 - audit.app.create
+- audit.app.build.create
 - audit.app.delete-request
 - audit.app.deployment.create
 - audit.app.droplet.create


### PR DESCRIPTION
The Event Type "audit.app.build.create" was missing in the list of App Lifecycle