### PR TITLE
Add doc for scaling guidance for CAPI in cf-for-k8s

### DIFF
--- a/managing-cf/scaling-cloud-controller-k8s.html.md.erb
+++ b/managing-cf/scaling-cloud-controller-k8s.html.md.erb
@@ -9,7 +9,7 @@ This topic describes how and when to scale CAPI in cf-for-k8s, and includes deta
 
 ## <a id='cf-api-server'></a> cf-api-server
 
-The `cf-api-server` is the primary container in CAPI. It, along with `nginx`, powers the Cloud Controller API that all users of Cloud Foundry interact with. In addition to serving external clients, `cf-api-server` also provides APIs for internal components within Cloud Foundry, such as Logging and Networking subsystems.
+The `cf-api-server` is the primary container in CAPI. It, along with `nginx`, powers the Cloud Controller API that all users of Cloud Foundry interact with. In addition to serving external clients, `cf-api-server` also provides APIs for internal components within Cloud Foundry, such as logging and networking subsystems.
 
 ### When to Scale
 
@@ -40,13 +40,13 @@ You can find the above heuristic failures in the following logs:
 
 Before and after scaling Cloud Controller API pods, you should verify that the Cloud Controller database is not overloaded. All Cloud Controller processes are backed by the same database, so heavy load on the database impacts API performance regardless of the number of Cloud Controllers deployed. Cloud Controller supports both PostgreSQL and MySQL, so there is no specific scaling guidance for the database.
 
-Cloud Controller API pods should primarily be scaled horizontally. Scaling up the number of compute resources requested past 1 CPU is not effective. This is because Ruby's Global Interpreter Lock (GIL) limits the `cloud_controller_ng` process so that it can only effectively use a single CPU core on a multi-core machine.
+Cloud Controller API pods should primarily be scaled horizontally. Scaling up the number of compute resources requested past one CPU is not effective. This is because Ruby's Global Interpreter Lock (GIL) limits the `cloud_controller_ng` process so that it can only effectively use a single CPU core on a multi-core machine.
 
 <p class='note'><strong>Note:</strong> Since Cloud Controller supports both PostgreSQL and MySQL external databases, there is no absolute guidance on what a healthy database looks like. In general, high database CPU utilization is a good indicator of scaling issues, but always defer to the documentation specific to your database.</p>
 
 ## <a id='cf-api-local-worker'></a> cf-api-local-worker
 
-Colloquially known as "local workers," this container is primarily responsible for handling files uploaded to the API pods during `cf push`, such as `packages`, `droplets`, and resource matching.
+Known as "local workers," this container is primarily responsible for handling files uploaded to the API pods during `cf push`, such as `packages`, `droplets`, and resource matching.
 
 ### When to Scale
 
@@ -74,11 +74,11 @@ You can find the above heuristic failures in the following logs:
 
 ### How to Scale
 
-Because local workers are colocated with the Cloud Controller API pod, they are scaled horizontally along with the API.
+Because local workers are co-located with the Cloud Controller API pod, they are scaled horizontally along with the API.
 
 ## <a id='cf-api-worker'></a> cf-api-worker
 
-Colloquially known as "generic workers" or just "workers", these pods are responsible for handling asynchronous work, batch deletes, and other periodic tasks scheduled by the `cf-api-clock`.
+Known as "generic workers" or just "workers", these pods are responsible for handling asynchronous work, batch deletes, and other periodic tasks scheduled by the `cf-api-clock`.
 
 ### When to Scale
 
@@ -88,7 +88,7 @@ When determining whether to scale `cf-api-worker`, look for the following:
 
 Cloud Controller emits the following metrics:
 
-* `cc_job_queue_length_cc-CF_API_WORKER_POD_NAME` (e.g. `cc_job_queue_length_cc_cf_api_worker_565c45df86_h2nsp`) is continuously growing.
+* `cc_job_queue_length_cc-CF_API_WORKER_POD_NAME` (for example, `cc_job_queue_length_cc_cf_api_worker_565c45df86_h2nsp`) is continuously growing.
 * `cc_job_queue_length_total` is continuously growing.
 
 #### Heuristic Failures
@@ -107,7 +107,7 @@ You can find the above heuristic failures in the following log files:
 
 ### How to Scale
 
-The cf-api-worker pod can safely scale horizontally in all deployments.
+The `cf-api-worker` pod can safely scale horizontally in all deployments.
 
 ## <a id='clock_and_updater'></a> cf-api-clock and cf-api-deployment-updater
 
@@ -139,5 +139,4 @@ You can find the above heuristic failures in the following log files:
 
 ### How to Scale
 
-Both of these pods are singletons, so extra instances are for failover HA rather than scalability. Performance issues are likely due to database overloading.
-
+Both of these pods are singletons, so extra instances are for failover high availability rather than scalability. Performance issues are likely due to database overloading.

--- a/managing-cf/scaling-cloud-controller-k8s.html.md.erb
+++ b/managing-cf/scaling-cloud-controller-k8s.html.md.erb
@@ -1,0 +1,143 @@
+---
+title: Scaling Cloud Controller (cf-for-k8s)
+owner: CAPI
+---
+
+
+This topic describes how and when to scale CAPI in cf-for-k8s, and includes details about some key metrics, heuristics, and logs.
+
+
+## <a id='cf-api-server'></a> cf-api-server
+
+The `cf-api-server` is the primary container in CAPI. It, along with `nginx`, powers the Cloud Controller API that all users of Cloud Foundry interact with. In addition to serving external clients, `cf-api-server` also provides APIs for internal components within Cloud Foundry, such as Logging and Networking subsystems.
+
+### When to Scale
+
+When determining whether to scale `cf-api-server`, look for the following:
+
+#### Key Metrics
+
+Cloud Controller emits the following metrics:
+
+* `sum(rate(container_cpu_usage_seconds_total{container="cf-api-server"}[1m])) by (pod)` is above 0.85 utilization of a single pod's CPU allocation.
+* `cc_vitals_uptime` is consistently low, indicating frequent restarts (possibly due to memory pressure).
+
+#### Heuristic Failures
+
+The following behaviors may occur:
+
+* There is a latency in average response.
+* Web UI responsiveness or timeouts are degraded.
+
+#### Relevant Logs
+
+You can find the above heuristic failures in the following logs:
+
+* `kapp logs -a cf -m 'cf-api-server%' -c cf-api-server`
+* `kapp logs -a cf -m 'cf-api-server%' -c nginx`
+
+### How to Scale
+
+Before and after scaling Cloud Controller API pods, you should verify that the Cloud Controller database is not overloaded. All Cloud Controller processes are backed by the same database, so heavy load on the database impacts API performance regardless of the number of Cloud Controllers deployed. Cloud Controller supports both PostgreSQL and MySQL, so there is no specific scaling guidance for the database.
+
+Cloud Controller API pods should primarily be scaled horizontally. Scaling up the number of compute resources requested past 1 CPU is not effective. This is because Ruby's Global Interpreter Lock (GIL) limits the `cloud_controller_ng` process so that it can only effectively use a single CPU core on a multi-core machine.
+
+<p class='note'><strong>Note:</strong> Since Cloud Controller supports both PostgreSQL and MySQL external databases, there is no absolute guidance on what a healthy database looks like. In general, high database CPU utilization is a good indicator of scaling issues, but always defer to the documentation specific to your database.</p>
+
+## <a id='cf-api-local-worker'></a> cf-api-local-worker
+
+Colloquially known as "local workers," this container is primarily responsible for handling files uploaded to the API pods during `cf push`, such as `packages`, `droplets`, and resource matching.
+
+### When to Scale
+
+When determining whether to scale `cf-api-local-worker`, look for the following:
+
+#### Key Metrics
+
+Cloud Controller emits the following metrics:
+
+* `cc_job_queue_length_cc-CF_API_SERVER_POD_NAME` is continuously growing.
+* `cc_job_queue_length_total` is continuously growing.
+
+#### Heuristic Failures
+
+The following behaviors may occur:
+
+* `cf push` is intermittently failing.
+* `cf push` average time is elevated.
+
+#### Relevant Logs
+
+You can find the above heuristic failures in the following logs:
+
+* `kapp logs -a cf -m 'cf-api-server%' -c cf-api-server`
+
+### How to Scale
+
+Because local workers are colocated with the Cloud Controller API pod, they are scaled horizontally along with the API.
+
+## <a id='cf-api-worker'></a> cf-api-worker
+
+Colloquially known as "generic workers" or just "workers", these pods are responsible for handling asynchronous work, batch deletes, and other periodic tasks scheduled by the `cf-api-clock`.
+
+### When to Scale
+
+When determining whether to scale `cf-api-worker`, look for the following:
+
+#### Key Metrics
+
+Cloud Controller emits the following metrics:
+
+* `cc_job_queue_length_cc-CF_API_WORKER_POD_NAME` (e.g. `cc_job_queue_length_cc_cf_api_worker_565c45df86_h2nsp`) is continuously growing.
+* `cc_job_queue_length_total` is continuously growing.
+
+#### Heuristic Failures
+
+The following behaviors may occur:
+
+* `cf delete-org ORG_NAME` appears to leave its contained resources around for a long time.
+* Users report slow deletes for other resources.
+* cf-acceptance-tests succeed generally, but fail during cleanup.
+
+#### Relevant Logs
+
+You can find the above heuristic failures in the following log files:
+
+* `kapp logs -m 'cf-api-worker%' -c cf-api-worker`
+
+### How to Scale
+
+The cf-api-worker pod can safely scale horizontally in all deployments.
+
+## <a id='clock_and_updater'></a> cf-api-clock and cf-api-deployment-updater
+
+The `cf-api-clock` job runs the Eirini sync process and schedules periodic background jobs. The `cf-api-deployment-updater` job is responsible for handling v3 rolling app deployments. For more information, see [Rolling App Deployments (Beta)](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html).
+
+### When to Scale
+
+When determining whether to scale `cf-api-clock` and `cf-api-deployment-updater`, look for the following:
+
+#### Key Metrics
+
+Cloud Controller emits the following metrics:
+
+* `sum(rate(container_cpu_usage_seconds_total{container="cf-api-clock"}[1m])) by (pod)` is high (approaching 1.0).
+
+#### Heuristic Failures
+
+The following behaviors may occur:
+
+* The number of workload pods in the `cf-workloads` namespace does not match the total process instance count reported through the Cloud Controller APIs.
+* Deployments are slow to increase and decrease instance count.
+
+#### Relevant Logs
+
+You can find the above heuristic failures in the following log files:
+
+* `kapp logs -m 'cf-api-clock%' -c cf-api-clock`
+* `kapp logs -m 'cf-api-deployment-updater%' -c cf-api-deployment-updater`
+
+### How to Scale
+
+Both of these pods are singletons, so extra instances are for failover HA rather than scalability. Performance issues are likely due to database overloading.
+


### PR DESCRIPTION
Hello,

We are adding new documentation for cf-for-k8s. This would probably also require changes to https://github.com/cloudfoundry/docs-book-cloudfoundry in order to add a link for this page somewhere in the sidebar, but we're not entirely sure where cf-for-k8s documentation should fit in there.

Let us know please of course if there is any issues with the content itself.

Thank you,
Jwal + @tcdowney 