### PR TITLE
Service broker rate limit header

### DIFF
--- a/rate-limit-cloud-controller-api.html.md.erb
+++ b/rate-limit-cloud-controller-api.html.md.erb
@@ -42,6 +42,17 @@ When requests exceed the maximum rate limit value, the Cloud Controller API retu
 
 ## <a id="Rate Limit Responses: Service Brokers"></a> Rate Limit Responses: Service Brokers
 
-The optional limit on the number of concurrent service broker requests will, when breached, result in a response that includes a Retry-After header. This gives an _absolute_ time suggesting when the client should attempt to make their request again. This is the current time plus a random number of seconds between 0.5x and 1.5x of the configured value for `cc.broker_client_timeout_seconds`.
+Operators can, optionally, limit the number of concurrent requests for operations related to service brokers that can be made to Cloud Controller API endpoints for the following resource types:
+
+* [`v3/service_instances`](https://v3-apidocs.cloudfoundry.org/index.html#service-instances)
+* [`v3/service_credential_bindings`](https://v3-apidocs.cloudfoundry.org/index.html#service-credential-binding)
+* [`v3/service_route_binding`](https://v3-apidocs.cloudfoundry.org/index.html#service-route-binding)
+* [`v2/service_instances`](https://apidocs.cloudfoundry.org/#service-instances)
+* [`v2/service_bindings`](https://apidocs.cloudfoundry.org/#service-bindings)
+* [`v2/service_keys`](https://apidocs.cloudfoundry.org/#service-keys)
+
+<p class="note"><strong>Note</strong>: A request finishes when the Cloud Controller API sends a response, even if that response is a `202 Accepted` indicating that an [asynchronous operation](https://v3-apidocs.cloudfoundry.org/index.html#asynchronous-operations) is to be performed (for example, the creation of a service instance by a service broker). This rate limit does _not_ cap the number of asynchronous operations that can be in progress at any one time for any of the above service-related endpoints.
+
+Any requests that breach the concurrency are rate limited, and will receive a response that includes a Retry-After header. This gives an _absolute_ time suggesting when the client should attempt to make their request again. This is the current time plus a random number of seconds between 0.5x and 1.5x of the configured value for `cc.broker_client_timeout_seconds`.
 
 If this property is not set, it defaults to 60 seconds, and the header will therefore suggest a random retry time between 30 and 90 seconds in the future.

--- a/rate-limit-cloud-controller-api.html.md.erb
+++ b/rate-limit-cloud-controller-api.html.md.erb
@@ -3,6 +3,10 @@ title: Rate Limit Information Returned by the Cloud Controller API
 owner: CAPI
 ---
 
+See [here](./setting-rate-limit-cloud-api.html) for information how to configure rate limits.
+
+## <a id="Rate Limit Responses: General"></a> Rate Limit Responses: General
+
 The Cloud Controller API includes rate limit information in the HTTP header. Each header includes the following:
 
 ```
@@ -35,3 +39,9 @@ The estimate is based on the fraction remaining on the Cloud Controller instance
 This might result in inconsistent values for the `X-RateLimit-Remaining` header when running multiple instances of Cloud Controller API, such as some requests still being allowed when the header value is `0`.
 
 When requests exceed the maximum rate limit value, the Cloud Controller API returns a `429: Too Many Requests` error code.
+
+## <a id="Rate Limit Responses: Service Brokers"></a> Rate Limit Responses: Service Brokers
+
+The optional limit on the number of concurrent service broker requests will, when breached, result in a response that includes a Retry-After header. This gives an _absolute_ time suggesting when the client should attempt to make their request again. This is the current time plus a random number of seconds between 0.5x and 1.5x of the configured value for `cc.broker_client_timeout_seconds`.
+
+If this property is not set, it defaults to 60 seconds, and the header will therefore suggest a random retry time between 30 and 90 seconds in the future.

--- a/rate-limit-cloud-controller-api.html.md.erb
+++ b/rate-limit-cloud-controller-api.html.md.erb
@@ -42,7 +42,7 @@ When requests exceed the maximum rate limit value, the Cloud Controller API retu
 
 ## <a id="Rate Limit Responses: Service Brokers"></a> Rate Limit Responses: Service Brokers
 
-Operators can, optionally, limit the number of concurrent requests for operations related to service brokers that can be made to Cloud Controller API endpoints for the following resource types:
+Operators can, optionally, limit the number of concurrent requests per user _for each Cloud Controller instance_ for operations related to service brokers that can be made to Cloud Controller API endpoints for the following resource types:
 
 * [`v3/service_instances`](https://v3-apidocs.cloudfoundry.org/index.html#service-instances)
 * [`v3/service_credential_bindings`](https://v3-apidocs.cloudfoundry.org/index.html#service-credential-binding)
@@ -51,8 +51,10 @@ Operators can, optionally, limit the number of concurrent requests for operation
 * [`v2/service_bindings`](https://apidocs.cloudfoundry.org/#service-bindings)
 * [`v2/service_keys`](https://apidocs.cloudfoundry.org/#service-keys)
 
+<p class="note"><strong>Note</strong>: Unlike with the Cloud Controller API rate limit, which caps the requests a user can make across the whole Cloud Foundry platform, service broker rate limits apply per Cloud Controller API instance. If the limit is 3 and there are 2 instances, the maximum number of concurrent requests a user could make would therefore be 6.
+
 <p class="note"><strong>Note</strong>: A request finishes when the Cloud Controller API sends a response, even if that response is a `202 Accepted` indicating that an [asynchronous operation](https://v3-apidocs.cloudfoundry.org/index.html#asynchronous-operations) is to be performed (for example, the creation of a service instance by a service broker). This rate limit does _not_ cap the number of asynchronous operations that can be in progress at any one time for any of the above service-related endpoints.
 
-Any requests that breach the concurrency are rate limited, and will receive a response that includes a Retry-After header. This gives an _absolute_ time suggesting when the client should attempt to make their request again. This is the current time plus a random number of seconds between 0.5x and 1.5x of the configured value for `cc.broker_client_timeout_seconds`.
+Any requests that breach the concurrency are rate limited, and will receive a `429 Too Many Requests` response with the body `CF-ServiceBrokerRateLimitExceeded (10016)` and a Retry-After header. The latter gives an _absolute_ time suggesting when the client should attempt to make their request again. This is the current time plus a random number of seconds between 0.5x and 1.5x of the configured value for `cc.broker_client_timeout_seconds`.
 
 If this property is not set, it defaults to 60 seconds, and the header will therefore suggest a random retry time between 30 and 90 seconds in the future.

--- a/setting-rate-limit-cloud-api.html.md.erb
+++ b/setting-rate-limit-cloud-api.html.md.erb
@@ -5,7 +5,9 @@ owner: CAPI
 
 Cloud Foundry lets you set rate limits on the number of requests third parties can make to the Cloud Controller API. You can set different rate limits for authenticated and unauthenticated users.
 
-When rate limiting is enabled responses to API calls [contain information](./rate-limit-cloud-controller-api.html) about the limit, how close the user is to reaching it, and when it will be reset.
+Rate limits help to prevent servers from getting overloaded by poorly or maliciously-designed clients that could otherwise force the server to use all its resources servicing those calls instead of responding to legitimate requests.
+
+When rate limiting is enabled responses to Cloud Controller API calls [contain information](./rate-limit-cloud-controller-api.html) about the limit, how close the user is to reaching it, and when it will be reset.
 
 Use the following properties in the `cloud_controller_ng` BOSH job to define rate limits:
 

--- a/setting-rate-limit-cloud-api.html.md.erb
+++ b/setting-rate-limit-cloud-api.html.md.erb
@@ -36,16 +36,6 @@ Use the following properties in the `cloud_controller_ng` BOSH job to define rat
     <td>60</td>
  </tr>
  <tr>
-    <td>cc.nginx_rate_limit_general</td>
-    <td>The rate limiting and burst value to use for '/'</td>
-    <td>(none)</td>
- </tr>
- <tr>
-    <td>cc.nginx_rate_limit_zones</td>
-    <td>Array of zones to do rate limiting for.</td>
-    <td>(none)</td>
- </tr>
- <tr>
     <td>cc.max_concurrent_service_broker_requests</td>
     <td>Maximum number of concurrent requests to <a href=./rate-limit-cloud-controller-api.html#Rate%20Limit%20Responses:%20Service%20Brokers>endpoints related to service brokers</a> (note that for this purpose a request ends immediately after a response is sent, even if the request is for an asynchronous operation that is still ongoing - e.g. service instance creation). Set to 0 to not limit concurrent requests.</td>
     <td>0</td>

--- a/setting-rate-limit-cloud-api.html.md.erb
+++ b/setting-rate-limit-cloud-api.html.md.erb
@@ -17,12 +17,12 @@ Use the following properties in the `cloud_controller_ng` BOSH job to define rat
 <th>Default value</th>
  <tr>
 	<td>cc.rate_limiter.enabled</td>
-	<td>Enable rate limiting for UAA-authenticated Cloud Controller API endpoints per user or client</td>
+	<td>Enable rate limiting for authenticated and unauthenticated Cloud Controller API endpoints per user or client</td>
     <td>false</td>
  </tr>
  <tr>
 	<td>cc.rate_limiter.general_limit</td>
-	<td>The number of requests a user or client is allowed to make for all Cloud Controller API endpoints that do not have a custom limit over the configured interval</td>
+	<td>The number of requests an authenticated user or client is allowed to make for all Cloud Controller API endpoints over the configured interval.</td>
     <td>2000</td>
  </tr>
  <tr>

--- a/setting-rate-limit-cloud-api.html.md.erb
+++ b/setting-rate-limit-cloud-api.html.md.erb
@@ -15,22 +15,22 @@ Use the following properties in the `cloud_controller_ng` BOSH job to define rat
 <th>Default value</th>
  <tr>
 	<td>cc.rate_limiter.enabled</td>
-	<td>Enable rate limiting for UAA-authenticated endpoints per user or client</td>
+	<td>Enable rate limiting for UAA-authenticated Cloud Controller API endpoints per user or client</td>
     <td>false</td>
  </tr>
  <tr>
 	<td>cc.rate_limiter.general_limit</td>
-	<td>The number of requests a user or client is allowed to make for all endpoints that do not have a custom limit over the configured interval</td>
+	<td>The number of requests a user or client is allowed to make for all Cloud Controller API endpoints that do not have a custom limit over the configured interval</td>
     <td>2000</td>
  </tr>
  <tr>
 	<td>cc.rate_limiter.unauthenticated_limit</td>
-	<td>The number of requests an unauthenticated client is allowed to make over the configured interval</td>
+	<td>The number of requests an unauthenticated client is allowed to to Cloud Controller API endpoints make over the configured interval</td>
     <td>100</td>
  </tr>
  <tr>
 	<td>cc.rate_limiter.reset_interval_in_minutes</td>
-	<td>The interval in minutes after which a user's available API requests will be reset</td>
+	<td>The interval in minutes after which a user's available Cloud Controller API requests will be reset</td>
     <td>60</td>
  </tr>
  <tr>
@@ -45,7 +45,7 @@ Use the following properties in the `cloud_controller_ng` BOSH job to define rat
  </tr>
  <tr>
     <td>cc.max_concurrent_service_broker_requests</td>
-    <td>Maximum number of concurrent requests to service brokers per user (note that for this purpose a request ends immediately after a response is sent, even if the request is for an asynchronous operation that is still ongoing - e.g. service instance creation). Set to 0 to not limit concurrent requests.</td>
+    <td>Maximum number of concurrent requests to <a href=./rate-limit-cloud-controller-api.html#Rate%20Limit%20Responses:%20Service%20Brokers>endpoints related to service brokers</a> (note that for this purpose a request ends immediately after a response is sent, even if the request is for an asynchronous operation that is still ongoing - e.g. service instance creation). Set to 0 to not limit concurrent requests.</td>
     <td>0</td>
  </td>
 </table>

--- a/setting-rate-limit-cloud-api.html.md.erb
+++ b/setting-rate-limit-cloud-api.html.md.erb
@@ -5,11 +5,47 @@ owner: CAPI
 
 Cloud Foundry lets you set rate limits on the number of requests third parties can make to the Cloud Controller API. You can set different rate limits for authenticated and unauthenticated users.
 
-Use the following properties in the cloud_controller BOSH job to define rate limits:
+When rate limiting is enabled responses to API calls [contain information](./rate-limit-cloud-controller-api.html) about the limit, how close the user is to reaching it, and when it will be reset.
 
-```
-cc.rate_limiter.enabled
-cc.rate_limiter.general_limit
-cc.rate_limiter.unauthenticated_limit
-cc.rate_limiter.reset_interval_in_minutes
-```
+Use the following properties in the `cloud_controller_ng` BOSH job to define rate limits:
+
+<table>
+<th>Property</th>
+<th>Description</th>
+<th>Default value</th>
+ <tr>
+	<td>cc.rate_limiter.enabled</td>
+	<td>Enable rate limiting for UAA-authenticated endpoints per user or client</td>
+    <td>false</td>
+ </tr>
+ <tr>
+	<td>cc.rate_limiter.general_limit</td>
+	<td>The number of requests a user or client is allowed to make for all endpoints that do not have a custom limit over the configured interval</td>
+    <td>2000</td>
+ </tr>
+ <tr>
+	<td>cc.rate_limiter.unauthenticated_limit</td>
+	<td>The number of requests an unauthenticated client is allowed to make over the configured interval</td>
+    <td>100</td>
+ </tr>
+ <tr>
+	<td>cc.rate_limiter.reset_interval_in_minutes</td>
+	<td>The interval in minutes after which a user's available API requests will be reset</td>
+    <td>60</td>
+ </tr>
+ <tr>
+    <td>cc.nginx_rate_limit_general</td>
+    <td>The rate limiting and burst value to use for '/'</td>
+    <td>(none)</td>
+ </tr>
+ <tr>
+    <td>cc.nginx_rate_limit_zones</td>
+    <td>Array of zones to do rate limiting for.</td>
+    <td>(none)</td>
+ </tr>
+ <tr>
+    <td>cc.max_concurrent_service_broker_requests</td>
+    <td>Maximum number of concurrent requests to service brokers per user (note that for this purpose a request ends immediately after a response is sent, even if the request is for an asynchronous operation that is still ongoing - e.g. service instance creation). Set to 0 to not limit concurrent requests.</td>
+    <td>0</td>
+ </td>
+</table>


### PR DESCRIPTION
Document proposed new Retry-After header for sb rate limiter. This updates doc pages [here](https://docs.cloudfoundry.org/running/rate-limit-cloud-controller-api.html) and [here](https://docs.cloudfoundry.org/running/setting-rate-limit-cloud-api.html).

See https://github.com/cloudfoundry/cloud_controller_ng/pull/2728