### PR TITLE
Fix: rename cf-release to cf-deployment

### DIFF
--- a/managing-cf/logging.html.md.erb
+++ b/managing-cf/logging.html.md.erb
@@ -13,7 +13,7 @@ The Cloud Foundry components share a common interface for configuring logs. For 
 Controller](http://github.com/cloudfoundry/cloud_controller_ng#logs), or for
 [Steno](http://github.com/cloudfoundry/steno), the logging library that Cloud Foundry components use.
 
-In `cf-release`, the components are all configured in a similar way:
+In `cf-deployment`, the components are all configured in a similar way:
 
 * All of the job's log files are located in the directory `/var/vcap/sys/log` of the machine on which the job is running.
 * The job's main logs are written to a file named `<job-name>.log`.
@@ -27,7 +27,7 @@ in the same directory.
 
 ## <a id='log-forwarding'></a> Log Forwarding
 
-Each BOSH job in `cf-release` includes a job named `metron_agent`. Metron itself acts as a forwarding agent for Doppler within the Loggregator metric system, but it also includes a [template](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/templates/syslog_forwarder.conf.erb) for configuring the `rsyslogd` daemon to forward logs to a remote machine. The [`syslog_daemon_config`](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec) properties include:
+Each BOSH job in `cf-deployment` includes a job named `metron_agent`. Metron itself acts as a forwarding agent for Doppler within the Loggregator metric system, but it also includes a [template](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/templates/syslog_forwarder.conf.erb) for configuring the `rsyslogd` daemon to forward logs to a remote machine. The [`syslog_daemon_config`](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec) properties include:
 
 * `syslog_daemon_config.address`: the IP address (or DNS name) of a remote system that should receive component logs from this VM
 * `syslog_daemon_config.port`: the port on which the log recipient is listening
@@ -42,4 +42,4 @@ properties:
     transport: udp
 ```
 
-Cloud Foundry no longer provides a component in `cf-release` for aggregating syslog messages from Cloud Foundry components.
+Cloud Foundry no longer provides a component in `cf-deployment` for aggregating syslog messages from Cloud Foundry components.

--- a/managing-cf/usage-events.html.md.erb
+++ b/managing-cf/usage-events.html.md.erb
@@ -16,7 +16,7 @@ Despite being similar in name, usage events are different from Cloud Foundry aud
 
 App usage events provide information about when users create, delete, and update apps. They also include information about the app to enable you to bill based on resource usage.
 
-App usage events expire after 31 days by default. You can configure a custom expiration period using the cf-release manifest property `cc.app_usage_events.cutoff_age_in_days`.
+App usage events expire after 31 days by default. You can configure a custom expiration period using the cf-deployment manifest property `cc.app_usage_events.cutoff_age_in_days`.
 
 #### <a id='app_usage_events_endpoint'></a> Endpoint
 
@@ -87,7 +87,7 @@ The app usage events with the `BUILDPACK_SET` state do not represent an actual a
 
 Service usage events provide information about when users create, update, and delete service instances.
 
-Service usage events expire after 31 days by default as of cf-release v226. You can configure a custom expiration period using the cf-release manifest property `cc.service_usage_events.cutoff_age_in_days`.
+Service usage events expire after 31 days by default in cf-deployment. You can configure a custom expiration period using the cf-deployment manifest property `cc.service_usage_events.cutoff_age_in_days`.
 
 #### <a id='service-usage-events-endpoint'></a> Endpoint
 


### PR DESCRIPTION
cf-release is deprecated.

Closes #105.