### PR TITLE
Fix: Log Forwarding documentation

### DIFF
--- a/managing-cf/logging.html.md.erb
+++ b/managing-cf/logging.html.md.erb
@@ -9,36 +9,23 @@ This section contains information for debugging Cloud Foundry system components.
 
 ## <a id='component-logging'></a> Component logging
 
-The Cloud Foundry components share a common interface for configuring logs. For more information, see the [Cloud Controller](http://github.com/cloudfoundry/cloud_controller_ng#logs), or for
-[Steno](http://github.com/cloudfoundry/steno), the logging library that Cloud Foundry components use.
+In `cf-deployment`, the components should all be configured in a similar way:
 
-In `cf-deployment`, the components are all configured in a similar way:
-
-* All of the job's log files are located in the directory `/var/vcap/sys/log` of the machine on which the job is running.
-* The job's main logs are written to a file named `<job-name>.log`.
+* All of the job's log files are located in the directory `/var/vcap/sys/log/<job-name>` of the machine on which the job is running.
 * Any output written directly to the job's stdout and stderr is written to `<job-name>.stdout.log` and `<job-name>.stderr.log`, respectively.
-
-### <a id='db-migration'></a> Database migrations
-
-For the Cloud Controller, database migration logs are written to `db_migrate.stdout.log` and `db_migrate.stderr.log`
-in the same directory.
+* Jobs may also write main logs to a file named `<job-name>.log`.
+* BOSH may also write logs for different lifecycle hooks to additional file paths, see [BOSH Update Lifecycle](https://bosh.io/docs/job-lifecycle/) for more details.
 
 
 ## <a id='log-forwarding'></a> Log forwarding
 
-Each BOSH job in `cf-deployment` includes a job named `metron_agent`. Metron itself acts as a forwarding agent for Doppler within the Loggregator metric system, but it also includes a [template](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/templates/syslog_forwarder.conf.erb) for configuring the `rsyslogd` daemon to forward logs to a remote machine. The [`syslog_daemon_config`](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec) properties include:
+BOSH VMs can be configured to forward component logs to remote syslog endpoints by applying the [enable-component-syslog.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/addons/enable-component-syslog.yml) ops file to a BOSH runtime config or manifest. The ops file requires some operator configuration ([example](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/addons/example-vars-files/vars-enable-component-syslog.yml)), including the following variables:
 
-* `syslog_daemon_config.address`: the IP address (or DNS name) of a remote system that should receive component logs from this VM
-* `syslog_daemon_config.port`: the port on which the log recipient is listening
-* `syslog_daemon_config.transport`: the protocol over which logs should be sent (one of `tcp` or `udp`); defaults to `tcp`
+* `syslog_address`: IP or DNS address of the syslog server.
+* `syslog_custom_rule`: Custom rsyslog rules.
+* `syslog_fallback_servers`: List of fallback servers to be used if the primary syslog server is down.
+* `syslog_permitted_peer`: Accepted fingerprint (SHA1) or name of remote peer.
+* `syslog_port`: Port of the syslog server.
 
-For example, to use UDP as the syslog transport, the manifest is similar to the following:
-```yaml
-properties:
-  syslog_daemon_config:
-    address: address.of.your.syslog.receiver
-    port: 54321
-    transport: udp
-```
+Further configuration options can be found in the [syslog_forwarder spec](https://github.com/cloudfoundry/syslog-release/blob/main/jobs/syslog_forwarder/spec).
 
-Cloud Foundry no longer provides a component in `cf-deployment` for aggregating syslog messages from Cloud Foundry components.


### PR DESCRIPTION
Updates very outdated information.

In particular, syslog forwarding is configured at the top-level now rather than being managed on a component-by-component basis.