### PR TITLE
Add new service related audit events

### DIFF
--- a/managing-cf/audit-events.html.md.erb
+++ b/managing-cf/audit-events.html.md.erb
@@ -195,6 +195,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.service\_binding.start\_create
 - audit.service\_binding.start\_delete
 - audit.service\_binding.update
+- audit.service\_binding.show
 
 
 ### <a id='service-broker-lifecycle'></a> Service broker lifecycle (audit.service\_broker.*)
@@ -217,6 +218,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.service\_instance.unbind\_route
 - audit.service\_instance.unshare
 - audit.service\_instance.update
+- audit.service\_instance.show
 
 ### <a id='service-route-lifecycle'></a> Service route lifecycle (audit.service\_route\_binding.*)
 
@@ -233,6 +235,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.service\_key.start\_create
 - audit.service\_key.start\_delete
 - audit.service\_key.update
+- audit.service\_key.show
 
 ### <a id='service-plan-vis-lifecycle'></a> Service plan visibility lifecycle (audit.service\_plan\_visibility.*)
 
@@ -269,6 +272,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.user\_provided\_service\_instance.create
 - audit.user\_provided\_service\_instance.delete
 - audit.user\_provided\_service\_instance.update
+- audit.user\_provided\_service\_instance.show
 
 ### <a id=special-events'></a> Special events
 


### PR DESCRIPTION
Cloud Controller has additional audit events for viewing service keys, service bindings and service instances.

Related cloud_controller_ng commit: https://github.com/cloudfoundry/cloud_controller_ng/commit/2f2f9785afc095c02cb63df3abd4610380ae460a

https://github.com/cloudfoundry/cloud_controller_ng/pull/3490