### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/managing-cf/app-event.html.md.erb
+++ b/managing-cf/app-event.html.md.erb
@@ -137,16 +137,16 @@ $ cf curl /v2/apps/acf2ce75-ee92-4bb6-9adb-55a596a8dcba/summary
 [...]
 </pre>
 
-To view the `app_usages` report that covers app usage within an org during a period of time, see [List all app usage events](https://apidocs.cloudfoundry.org/6.7.0/app_usage_events/list_all_app_usage_events.html) in the Cloud Foundry API documentation.
+To view the `app_usages` report that covers app usage within an org during a period of time, see [List all app usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-app-usage-events) in the Cloud Foundry API documentation.
 
 ### <a id='events'></a> Events
 
 Use the `events` endpoint to retrieve information about app events.
 
-For more information, see the [Audit events](./audit-events.html) topic and [List all events](https://apidocs.cloudfoundry.org/6.7.0/events/list_all_events.html) in the Cloud Foundry API documentation.
+For more information, see the [Audit events](./audit-events.html) topic and [List all events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-audit-events) in the Cloud Foundry API documentation.
 
 ### <a id='app-usage-events'></a> App usage events
 
 Use the `app-usage-events` endpoint to retrieve information about app usage events.
 
-For more information, see the [Usage events and billing](./usage-events.html) topic and [List all app usage events](https://apidocs.cloudfoundry.org/6.7.0/app_usage_events/list_all_app_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see the [Usage events and billing](./usage-events.html) topic and [List all app usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-app-usage-events) in the Cloud Foundry API documentation.

--- a/managing-cf/usage-events.html.md.erb
+++ b/managing-cf/usage-events.html.md.erb
@@ -69,7 +69,7 @@ $ GET /v2/app_usage_events
 }
 </pre>
 
-For more information, see [List all app usage events](https://apidocs.cloudfoundry.org/6.7.0/app_usage_events/list_all_app_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see [List all app usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-app-usage-events) in the Cloud Foundry API documentation.
 
 #### <a id='app-usage-events-event-states'></a> Event states
 
@@ -133,7 +133,7 @@ $ GET /v2/service_usage_events
 }
 </pre>
 
-For more information, see [List service usage events](http://apidocs.cloudfoundry.org/12.24.0/service_usage_events/list_service_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see [List service usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-service-usage-events) in the Cloud Foundry API documentation.
 
 #### <a id='service-usage-events-event-states'></a> Event states
 
@@ -186,7 +186,7 @@ To seed the app usage events with start events, run:
 POST /v2/app_usage_events/destructively_purge_all_and_reseed_started_apps
 ```
 
-For more information, see [Purge and reseed app usage events](http://apidocs.cloudfoundry.org/latest-release/app_usage_events/purge_and_reseed_app_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see [Purge and reseed app usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#purge-and-seed-app-usage-events) in the Cloud Foundry API documentation.
 
 To seed the service usage events with start events, run:
 
@@ -194,7 +194,7 @@ To seed the service usage events with start events, run:
 POST /v2/service_usage_events/destructively_purge_all_and_reseed_existing_instances
 ```
 
-For more information, see [Purge and reseed service usage events](http://apidocs.cloudfoundry.org/latest-release/service_usage_events/purge_and_reseed_service_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see [Purge and reseed service usage events](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#purge-and-seed-app-usage-events) in the Cloud Foundry API documentation.
 
 The purge endpoints create initial events for all apps or service instances. The seeded events all have the current timestamp, rather than the time the app was actually started.
 

--- a/rate-limit-cloud-controller-api.html.md.erb
+++ b/rate-limit-cloud-controller-api.html.md.erb
@@ -68,9 +68,9 @@ Operators can limit the number of concurrent requests per user, for each Cloud C
 * [`v3/service_instances`](https://v3-apidocs.cloudfoundry.org/index.html#service-instances)
 * [`v3/service_credential_bindings`](https://v3-apidocs.cloudfoundry.org/index.html#service-credential-binding)
 * [`v3/service_route_binding`](https://v3-apidocs.cloudfoundry.org/index.html#service-route-binding)
-* [`v2/service_instances`](https://apidocs.cloudfoundry.org/#service-instances)
-* [`v2/service_bindings`](https://apidocs.cloudfoundry.org/#service-bindings)
-* [`v2/service_keys`](https://apidocs.cloudfoundry.org/#service-keys)
+* [`v2/service_instances`](https://v2-apidocs.cloudfoundry.org/#service-instances)
+* [`v2/service_bindings`](https://v2-apidocs.cloudfoundry.org/#service-bindings)
+* [`v2/service_keys`](https://v2-apidocs.cloudfoundry.org/#service-keys)
 
 <p class="note">
 <span class="note__title">Important</span>


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)