### PR TITLE
Remove puma experimental label and make it the default

### DIFF
--- a/managing-cf/scaling-cloud-controller.html.md.erb
+++ b/managing-cf/scaling-cloud-controller.html.md.erb
@@ -17,7 +17,7 @@ The `cloud_controller_ng` Ruby process is the primary job in CAPI.
 It, along with `nginx_cc`, powers the Cloud Controller API that all users of <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) interact with.
 In addition to serving external clients, `cloud_controller_ng` also provides APIs for internal components within <%= vars.app_runtime_abbr %>, such as Loggregator and Networking subsystems.
 
-The `cloud_controller_ng` web server can either be Thin (Default) or Puma (Experimental). The characteristics of these web servers differ significantly. The Thin web server runs on a single process per VM, therefore scaling should be done horizontally by adding more VMs. Puma allows for multiple processes to run per VM, therefore scaling can be both vertical or horizontal.
+The `cloud_controller_ng` web server can either be Puma (Default) or Thin (Deprecated). The characteristics of these web servers differ significantly. The Thin web server runs on a single process per VM, therefore scaling should be done horizontally by adding more VMs. Puma allows for multiple processes to run per VM, therefore scaling can be both vertical or horizontal.
 
 
 ### When to Scale
@@ -74,12 +74,6 @@ additional Cloud Controllers exacerbating the issue.
 <span class="note__title"><strong>Note</strong></span>
 Since Cloud Controller supports both PostgreSQL and MySQL external databases, there is no absolute guidance about what a healthy database looks like. In general, high database CPU utilization is a good indicator of scaling issues, but always defer to the documentation specific to your database.</p>
 
-#### <a id='scale-thin'></a> Scaling Thin Web Server
-
-When deployed with the Thin web server, Cloud Controller API VMs should primarily be scaled horizontally.
-Scaling up the number of cores on a single VM is not effective.
-This is because Thin operates in a single process and Ruby's Global Interpreter Lock (GIL) limits the `cloud_controller_ng` process so that it can only effectively use a single CPU core on a multi-core machine.
-
 #### <a id='scale-puma'></a> Scaling Puma Web Server
 
 When deployed with the Puma web server, Cloud Controller API VMs can be scaled both vertically and horizontally. Puma supports multiple processes per VM and so can scale with the number of CPU cores available.
@@ -98,6 +92,12 @@ The following are loose recommendations for setting these parameters:
 * The max number of DB Connections per process should be at least equal to the max number of threads. This ensures a thread always has a DB connection available. However, when choosing the max number of DB connections be aware that this is per Puma worker. You may estimate the total number of connections by `Number of VMs x Number of Workers x Max DB Connections Per Process`. For example, if you had 2 VMs with 4 workers and 10 max DB connections per process, you may have up to 80 DB connections. Be careful this does not exeed any Database limit.
 
 If when switching to Puma you reduce the number of overall Cloud Controller API VMs, you may need to increase the number of Cloud Controller Local workers per VM to handle the increased load on the remaining API VMs. For more information, see [cloud_controller_worker_local](#cloud_controller_worker_local).
+
+#### <a id='scale-thin'></a> Scaling Thin Web Server
+
+When deployed with the Thin web server, Cloud Controller API VMs should primarily be scaled horizontally.
+Scaling up the number of cores on a single VM is not effective.
+This is because Thin operates in a single process and Ruby's Global Interpreter Lock (GIL) limits the `cloud_controller_ng` process so that it can only effectively use a single CPU core on a multi-core machine.
 
 #### Adjusting DB connection pool
 

--- a/managing-cf/scaling-cloud-controller.html.md.erb
+++ b/managing-cf/scaling-cloud-controller.html.md.erb
@@ -42,7 +42,6 @@ Cloud Controller emits the following metrics:
 * `cc_db_connection_wait_duration_seconds` indicates that threads have to wait for free DB connections.
 
 <p class="note">
-<span class="note__title"><strong>Note</strong></span>
 The above guidelines for Puma assume that the number of Puma workers is configured to be the same as the number of CPU cores on the VM - see <a href="#scale-puma">Scaling Puma Web Server</a> below. If you have configured Puma workers to be different than the number of CPU cores, you should adjust threshold calculations accordingly.</p>
 
 #### Heuristic Failures
@@ -71,7 +70,6 @@ When this happens, the MySQL VMs must be scaled up to prevent the added load of
 additional Cloud Controllers exacerbating the issue.
 
 <p class="note">
-<span class="note__title"><strong>Note</strong></span>
 Since Cloud Controller supports both PostgreSQL and MySQL external databases, there is no absolute guidance about what a healthy database looks like. In general, high database CPU utilization is a good indicator of scaling issues, but always defer to the documentation specific to your database.</p>
 
 #### <a id='scale-puma'></a> Scaling Puma Web Server


### PR DESCRIPTION
Puma is now the default GA webserver in Cloud controller