### PR TITLE
Correct audit.app.crash to app.crash

### DIFF
--- a/managing-cf/audit-events.html.md.erb
+++ b/managing-cf/audit-events.html.md.erb
@@ -281,7 +281,7 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 
 ### <a id=special-events'></a> Special events
 
-- audit.app.crash
+- app.crash
 - blob.remove\_orphan
 
 
@@ -292,7 +292,7 @@ For example, a user issuing a `cf stop APP_NAME` command causes an `audit.app.st
 
 * **Service events** (`audit.service*`) are created after the service broker has approved an interaction.
 
-* **Crash and rescheduling events** (`audit.app.crash`, `audit.app.process.crash|rescheduling`) are created when Diego marks an app instance as crashed or evacuates app instances from cells on Diego Cell VM restarts.
+* **Crash and rescheduling events** (`app.crash`, `audit.app.process.crash|rescheduling`) are created when Diego marks an app instance as crashed or evacuates app instances from cells on Diego Cell VM restarts.
 
 * **Blob events** (`blob.remove_orphan`) are created by a daily clean up job and do not represent user action.
 


### PR DESCRIPTION
I'm writing a tool that forwards CF audit events to another audit system.
I was checking for all audit types on our CF latform and noticed that I could not find type `audit.app.crash`, but `app.crash` instead.

For an example, see an anonymized audit event for type `app.crash`:

https://github.com/gogolok/cfauditevents-samples/blob/main/app.crash.json

Then I took a look at the cloud_controller_ng code base and found similar proof:

https://github.com/cloudfoundry/cloud_controller_ng/blob/2b5ac3a84600354fe1e7aa8033d8b4e41c22b3db/app/repositories/event_types.rb#L149