### PR TITLE
[TCF-104] Fix legacy CF CLI URL prefix in app-event.html.md.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ information about the publishing process.
 
 ## Branch map
 
-This branch is published through the [docs-book-application-service](https://github.gwd.broadcom.net/TNZ/docs-book-application-service) repository.
-
-| Branch  | EART version  | Doc Link      |
-|---------|---------------|---------------|
-| tcf-104 | EART 10.4     | [EART v10.4 staging](https://author-techdocs2-prod.adobecqms.net/us/en/vmware-tanzu/platform/elastic-application-runtime/10-4/eart/runtime-rn.html)
-| tcf-103 | EART 10.3     | [EART v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
-| tcf-102 | TPCF 10.2     | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
-| master  | TPCF 10.0     | archived PDF |
-| master  | TAS 6.0       | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
-| master  | TAS 5.0       | archived PDF  |
-| master  | TAS 4.0       | archived PDF  |
+| Branch  | EART version     | Doc Link      |
+|---------|------------------|---------------|
+| 10.5    | EART 10.5        | [EART v10.5 staging](https://author-techdocs2-prod.adobecqms.net/us/en/vmware-tanzu/platform/elastic-application-runtime/10-5/eart/runtime-rn.html)
+| tcf-104 | EART 10.4        | [EART v10.4](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-4/eart/runtime-rn.html)
+| tcf-103 | EART 10.3        | [EART v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
+| tcf-102 | TPCF 10.2        | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
+| tcf-10  | TPCF 10.0        | archived PDF |
+| 6.0     | TAS 6.0          | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
+| 5.0     | TAS 5.0 (EOGS)   | archived PDF  |
+| 4.0     | TAS v4.0 (EOGS)  | archived PDF  |
+| 3.0     | TAS v3.0 (EOGS)  | archived PDF  |
+| 2.13    | TAS v2.13 (EOGS) | archived PDF  |
+| 2.12    | TAS v2.12 (EOGS) | archived PDF  |
+| 2.11    | TAS v2.11 (EOGS) | archived PDF  |

--- a/managing-cf/app-event.html.md.erb
+++ b/managing-cf/app-event.html.md.erb
@@ -32,7 +32,7 @@ To perform the procedures in this topic, you must authenticate to your Cloud Con
   Org:             YOUR-ORG
   Space:           development
   </pre>
-    If you do not have the Tanzu cf CLI installed, see the [Installing the Tanzu cf CLI](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/install-cf-cli.html) topic
+    If you do not have the Tanzu cf CLI installed, see the [Installing the Tanzu cf CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/install-cf-cli.html) topic
 
 ## <a id='obtain_apps'></a> Obtain app information
 


### PR DESCRIPTION
## Summary

Companion to TNZ/docs-operating-pas#95. Fixes the CF CLI external link in `managing-cf/app-event.html.md.erb`:

- Removes the legacy `/content/broadcom/techdocs` URL prefix
- Switches `vars.current_major_version_url` to `vars.tanzu_cf_cli_version`

**File changed:**
- `managing-cf/app-event.html.md.erb` line 35 (link to `install-cf-cli.html`)

## Merge order

Independent of docs-operating-pas#95; can be merged at any time.

ai-assisted=yes
TNZ-95042