### PR TITLE
Add missing audit events for buildpacks, org/space quotas, stacks, and app builds

### DIFF
--- a/managing-cf/audit-events.html.md.erb
+++ b/managing-cf/audit-events.html.md.erb
@@ -123,6 +123,8 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 
 - audit.app.apply\_manifest
 - audit.app.build.create
+- audit.app.build.failed
+- audit.app.build.staged
 - audit.app.copy-bits
 - audit.app.create
 - audit.app.delete-request
@@ -163,12 +165,25 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.app.update
 - audit.app.upload-bits
 
+### <a id='buildpack-lifecycle'></a> Buildpack lifecycle (audit.buildpack.*)
+
+- audit.buildpack.create
+- audit.buildpack.delete
+- audit.buildpack.update
+- audit.buildpack.upload
 
 ### <a id='org-lifecycle'></a> Organization lifecycle (audit.organization.*)
 
 - audit.organization.create
 - audit.organization.delete-request
 - audit.organization.update
+
+### <a id='org-quota-lifecycle'></a> Organization quota lifecycle (audit.organization_quota.*)
+
+- audit.organization\_quota.apply
+- audit.organization\_quota.create
+- audit.organization\_quota.delete
+- audit.organization\_quota.update
 
 ### <a id='route-lifecycle'></a> Route lifecycle (audit.route.*)
 
@@ -252,6 +267,20 @@ For auditing and compliance reasons, some operators may wish to keep a record of
 - audit.space.create
 - audit.space.delete-request
 - audit.space.update
+
+### <a id='space-quota-lifecycle'></a> Space quota lifecycle (audit.space_quota.*)
+
+- audit.space\_quota.apply
+- audit.space\_quota.create
+- audit.space\_quota.delete
+- audit.space\_quota.remove
+- audit.space\_quota.update
+
+### <a id='stack-lifecycle'></a> Stack lifecycle (audit.stack.*)
+
+- audit.stack.create
+- audit.stack.delete
+- audit.stack.update
 
 ### <a id='user-lifecycle'></a> User lifecycle (audit.user.*)
 


### PR DESCRIPTION
## Summary

- Adds 19 audit events that were missing from the published list
- Fixes #141 (filed by gogolok, referencing cloud_controller_ng PRs)

**Changes:**
- `audit.app.build.failed` and `audit.app.build.staged` added to the App lifecycle section
- New **Buildpack lifecycle** section: `audit.buildpack.create`, `.delete`, `.update`, `.upload`
- New **Organization quota lifecycle** section: `audit.organization_quota.apply`, `.create`, `.delete`, `.update`
- New **Space quota lifecycle** section: `audit.space_quota.apply`, `.create`, `.delete`, `.remove`, `.update`
- New **Stack lifecycle** section: `audit.stack.create`, `.delete`, `.update`

All new sections follow the existing bullet-list format and are inserted in alphabetical order relative to surrounding sections.

## Test plan

- [ ] Confirm all 19 new events appear in `managing-cf/audit-events.html.md.erb`
- [ ] Confirm new sections are in alphabetical order relative to existing sections
- [ ] Confirm no prohibited terms introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)